### PR TITLE
Support basic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-spring/compare/0.1.1...0.2.0
 
+- Support basic auth
+
 ## [0.2.0][] - 2018-11-20
 
 [0.2.0]: https://github.com/chaostoolkit-incubator/chaostoolkit-spring/compare/0.1.1...0.2.0

--- a/chaosspring/api.py
+++ b/chaosspring/api.py
@@ -48,8 +48,19 @@ def call_api(base_url: str,
         data = json.dumps(assaults_configuration)
         headers.update({"Content-Type": "application/json"})
 
-    return requests.request(method=method,
-                            url=url,
-                            params=params,
-                            data=data,
-                            headers=headers)
+    if secrets:
+        username = secrets.get("username")
+        password = secrets.get("password")
+        return requests.request(method=method,
+                                url=url,
+                                params=params,
+                                data=data,
+                                headers=headers,
+                                auth=(username, password))
+
+    else:
+        return requests.request(method=method,
+                                url=url,
+                                params=params,
+                                data=data,
+                                headers=headers)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -106,3 +106,25 @@ def test_call_api_post_with_assaults_configuration():
 
     assert response.status_code == codes.ok
     assert response.text == "Chaos Monkey assaults configuration changed!"
+
+def test_call_api_get_with_basic_auth_secrets():
+    with requests_mock.mock() as m:
+        m.request(
+            "GET",
+            "http://localhost:8080/actuator/chaosmonkey/status",
+            status_code=codes.ok,
+            text="Ready to be evil!")
+
+        response = call_api(
+            base_url="http://localhost:8080/actuator",
+            api_endpoint="chaosmonkey/status",
+            assaults_configuration=None,
+            timeout=None,
+            configuration=None,
+            secrets={
+                "username":"user",
+                "password":"pass"
+            })
+
+    assert response.status_code == codes.ok
+    assert response.text == "Ready to be evil!"


### PR DESCRIPTION
I recently started using chaos toolkit.  My spring boot apps use [spring security](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-endpoints-security) to secure actuator endpoints.  

This adds support for basic auth.