### PR TITLE
Add ability to disable SSL Verification in Actions & Probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * Makefile to abstract away common development tasks
 * GitHub Actions workflows
+* Added `verify_ssl` argument to probes and actions to allow for disabling SSL verification
 
 ## [0.2.0][] - 2018-11-20
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ That's it!
 
 Please explore the code to use further probes and actions.
 
+### SSL Verification
+
+If you do not wish to have SSL Verification performed during your actions/probes
+then you can pass the argument `"verify_ssl": false` to the individual activities.
+
+If you wish to provide a `CA_BUNDLE` or directory of trusted CAs certificates,
+provide the environment variables specified in the `requests` documentation here:
+[Requests SSL Cert Verification](https://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification).
+
 ## Contribute
 
 If you wish to contribute more functions to this package, you are more than

--- a/chaosspring/actions.py
+++ b/chaosspring/actions.py
@@ -13,6 +13,7 @@ def enable_chaosmonkey(
     base_url: str,
     headers: Dict[str, Any] = None,
     timeout: float = None,
+    verify_ssl: bool = True,
     configuration: Configuration = None,
     secrets: Secrets = None,
 ) -> str:
@@ -26,6 +27,7 @@ def enable_chaosmonkey(
         method="POST",
         headers=headers,
         timeout=timeout,
+        verify=verify_ssl,
         configuration=configuration,
         secrets=secrets,
     )
@@ -40,6 +42,7 @@ def disable_chaosmonkey(
     base_url: str,
     headers: Dict[str, Any] = None,
     timeout: float = None,
+    verify_ssl: bool = True,
     configuration: Configuration = None,
     secrets: Secrets = None,
 ) -> str:
@@ -53,6 +56,7 @@ def disable_chaosmonkey(
         method="POST",
         headers=headers,
         timeout=timeout,
+        verify=verify_ssl,
         configuration=configuration,
         secrets=secrets,
     )
@@ -68,6 +72,7 @@ def change_assaults_configuration(
     assaults_configuration: Dict[str, Any],
     headers: Dict[str, Any] = None,
     timeout: float = None,
+    verify_ssl: bool = True,
     configuration: Configuration = None,
     secrets: Secrets = None,
 ) -> str:
@@ -82,6 +87,7 @@ def change_assaults_configuration(
         assaults_configuration=assaults_configuration,
         headers=headers,
         timeout=timeout,
+        verify=verify_ssl,
         configuration=configuration,
         secrets=secrets,
     )

--- a/chaosspring/api.py
+++ b/chaosspring/api.py
@@ -28,8 +28,8 @@ def call_api(
     :param assaults_configuration: assaults configuration to change spring
             boot chaos monkey setting
     :param timeout: the waiting time before connection timeout
-    :param verify: bool representing whether requests verifies the SSL certificate of
-        the url (For providing trusted CAs, see
+    :param verify: bool representing whether requests performs SSL Verification
+        (For providing trusted CAs, see
         https://github.com/chaostoolkit-incubator/chaostoolkit-spring#ssl-verification)
     :param configuration: It provides runtime value to actions and probes in
             Key/value, it may contains platform

--- a/chaosspring/api.py
+++ b/chaosspring/api.py
@@ -13,6 +13,7 @@ def call_api(
     assaults_configuration: Dict[str, Any] = None,
     headers: Dict[str, Any] = None,
     timeout: float = None,
+    verify: bool = True,
     configuration: Configuration = None,
     secrets: Secrets = None,
 ) -> Response:
@@ -27,6 +28,9 @@ def call_api(
     :param assaults_configuration: assaults configuration to change spring
             boot chaos monkey setting
     :param timeout: the waiting time before connection timeout
+    :param verify: bool representing whether requests verifies the SSL certificate of
+        the url (For providing trusted CAs, see
+        https://github.com/chaostoolkit-incubator/chaostoolkit-spring#ssl-verification)
     :param configuration: It provides runtime value to actions and probes in
             Key/value, it may contains platform
                     specific api parameters.
@@ -40,7 +44,7 @@ def call_api(
     headers = headers or {}
     headers.setdefault("Accept", "application/json")
 
-    params = {}
+    params = {"verify": verify}
     if timeout:
         params["timeout"] = timeout
 

--- a/chaosspring/probes.py
+++ b/chaosspring/probes.py
@@ -13,6 +13,7 @@ def chaosmonkey_enabled(
     base_url: str,
     headers: Dict[str, Any] = None,
     timeout: float = None,
+    verify_ssl: bool = True,
     configuration: Configuration = None,
     secrets: Secrets = None,
 ) -> bool:
@@ -26,6 +27,7 @@ def chaosmonkey_enabled(
         api_endpoint="chaosmonkey/status",
         headers=headers,
         timeout=timeout,
+        verify=verify_ssl,
         configuration=configuration,
         secrets=secrets,
     )
@@ -42,6 +44,7 @@ def watcher_configuration(
     base_url: str,
     headers: Dict[str, Any] = None,
     timeout: float = None,
+    verify_ssl: bool = True,
     configuration: Configuration = None,
     secrets: Secrets = None,
 ) -> Dict[str, Any]:
@@ -54,6 +57,7 @@ def watcher_configuration(
         api_endpoint="chaosmonkey/watcher",
         headers=headers,
         timeout=timeout,
+        verify=verify_ssl,
         configuration=configuration,
         secrets=secrets,
     )
@@ -68,6 +72,7 @@ def assaults_configuration(
     base_url: str,
     headers: Dict[str, Any] = None,
     timeout: float = None,
+    verify_ssl: bool = True,
     configuration: Configuration = None,
     secrets: Secrets = None,
 ) -> Dict[str, Any]:
@@ -80,6 +85,7 @@ def assaults_configuration(
         api_endpoint="chaosmonkey/assaults",
         headers=headers,
         timeout=timeout,
+        verify=verify_ssl,
         configuration=configuration,
         secrets=secrets,
     )

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -29,6 +29,31 @@ def test_enable_chaosmonkey():
         method="POST",
         headers=None,
         timeout=None,
+        verify=True,
+        configuration=None,
+        secrets=None,
+    )
+    assert text == "Chaos Monkey is enabled"
+
+
+def test_enable_chaosmonkey_without_ssl_verification():
+    mock_response = MagicMock(
+        Response, status_code=codes.ok, text="Chaos Monkey is enabled"
+    )
+    actuator_endpoint = "http://localhost:8080/actuator"
+
+    with mock.patch(
+        "chaosspring.api.call_api", return_value=mock_response
+    ) as mock_call_api:
+        text = enable_chaosmonkey(base_url=actuator_endpoint, verify_ssl=False)
+
+    mock_call_api.assert_called_once_with(
+        base_url=actuator_endpoint,
+        api_endpoint="chaosmonkey/enable",
+        method="POST",
+        headers=None,
+        timeout=None,
+        verify=False,
         configuration=None,
         secrets=None,
     )
@@ -52,6 +77,7 @@ def test_enable_chaosmonkey_fails():
         method="POST",
         headers=None,
         timeout=None,
+        verify=True,
         configuration=None,
         secrets=None,
     )
@@ -75,6 +101,31 @@ def test_disable_chaosmonkey():
         method="POST",
         headers=None,
         timeout=None,
+        verify=True,
+        configuration=None,
+        secrets=None,
+    )
+    assert text == "Chaos Monkey is disabled"
+
+
+def test_disable_chaosmonkey_without_ssl_verification():
+    mock_response = MagicMock(
+        Response, status_code=codes.ok, text="Chaos Monkey is disabled"
+    )
+    actuator_endpoint = "http://localhost:8080/actuator"
+
+    with mock.patch(
+        "chaosspring.api.call_api", return_value=mock_response
+    ) as mock_call_api:
+        text = disable_chaosmonkey(base_url=actuator_endpoint, verify_ssl=False)
+
+    mock_call_api.assert_called_once_with(
+        base_url=actuator_endpoint,
+        api_endpoint="chaosmonkey/disable",
+        method="POST",
+        headers=None,
+        timeout=None,
+        verify=False,
         configuration=None,
         secrets=None,
     )
@@ -98,6 +149,7 @@ def test_disable_chaosmonkey_fails():
         method="POST",
         headers=None,
         timeout=None,
+        verify=True,
         configuration=None,
         secrets=None,
     )
@@ -134,6 +186,46 @@ def test_change_assaults_configuration():
         assaults_configuration=assaults_configuration,
         headers=None,
         timeout=None,
+        verify=True,
+        configuration=None,
+        secrets=None,
+    )
+    assert changed == "Assault config has changed"
+
+
+def test_change_assaults_configuration_without_ssl_verification():
+    assaults_configuration = {
+        "level": 5,
+        "latencyRangeStart": 2000,
+        "latencyRangeEnd": 5000,
+        "latencyActive": True,
+        "exceptionsActive": True,
+        "killApplicationActive": False,
+        "restartApplicationActive": False,
+    }
+
+    mock_response = MagicMock(
+        Response, status_code=codes.ok, text="Assault config has changed"
+    )
+
+    actuator_endpoint = "http://localhost:8080/actuator"
+    with mock.patch(
+        "chaosspring.api.call_api", return_value=mock_response
+    ) as mock_call_api:
+        changed = change_assaults_configuration(
+            base_url=actuator_endpoint,
+            assaults_configuration=assaults_configuration,
+            verify_ssl=False,
+        )
+
+    mock_call_api.assert_called_once_with(
+        base_url=actuator_endpoint,
+        api_endpoint="chaosmonkey/assaults",
+        method="POST",
+        assaults_configuration=assaults_configuration,
+        headers=None,
+        timeout=None,
+        verify=False,
         configuration=None,
         secrets=None,
     )
@@ -171,6 +263,7 @@ def test_change_assaults_configuration_fails():
         assaults_configuration=assaults_configuration,
         headers=None,
         timeout=None,
+        verify=True,
         configuration=None,
         secrets=None,
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,8 @@
+from unittest.mock import MagicMock, Mock, patch
+
 import requests_mock
 from requests import codes
+from requests.models import Response
 
 from chaosspring.api import call_api
 
@@ -24,6 +27,65 @@ def test_call_api_get():
 
     assert response.status_code == codes.ok
     assert response.text == "Ready to be evil!"
+
+
+@patch("chaosspring.api.requests.request", autospec=True)
+def test_call_api_without_verification(mocked_request: MagicMock):
+    mock_resp = Mock(Response)
+    expected_status_code = codes.ok
+    expected_text = "Ready to be evil"
+    mock_resp.status_code = expected_status_code
+    mock_resp.text = expected_text
+    mocked_request.return_value = mock_resp
+    response = call_api(
+        base_url="http://localhost:8080/actuator",
+        api_endpoint="chaosmonkey/status",
+        assaults_configuration=None,
+        timeout=3000,
+        verify=False,
+        configuration=None,
+        secrets=None,
+    )
+
+    assert response.status_code == expected_status_code
+    assert response.text == expected_text
+
+    mocked_request.assert_called_once_with(
+        method="GET",
+        url="http://localhost:8080/actuator/chaosmonkey/status",
+        params={"timeout": 3000, "verify": False},
+        data=None,
+        headers={"Accept": "application/json"},
+    )
+
+
+@patch("chaosspring.api.requests.request", autospec=True)
+def test_call_api_with_verification(mocked_request: MagicMock):
+    mock_resp = Mock(Response)
+    expected_status_code = codes.ok
+    expected_text = "Ready to be evil"
+    mock_resp.status_code = expected_status_code
+    mock_resp.text = expected_text
+    mocked_request.return_value = mock_resp
+    response = call_api(
+        base_url="http://localhost:8080/actuator",
+        api_endpoint="chaosmonkey/status",
+        assaults_configuration=None,
+        timeout=3000,
+        configuration=None,
+        secrets=None,
+    )
+
+    assert response.status_code == expected_status_code
+    assert response.text == expected_text
+
+    mocked_request.assert_called_once_with(
+        method="GET",
+        url="http://localhost:8080/actuator/chaosmonkey/status",
+        params={"timeout": 3000, "verify": True},
+        data=None,
+        headers={"Accept": "application/json"},
+    )
 
 
 def test_call_api_post():

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -27,6 +27,28 @@ def test_chaosmonkey_is_enabled():
         api_endpoint="chaosmonkey/status",
         headers=None,
         timeout=None,
+        verify=True,
+        configuration=None,
+        secrets=None,
+    )
+
+
+def test_chaosmonkey_is_enabled_without_ssl_verification():
+    mock_response = MagicMock(Response, status_code=codes.ok)
+    actuator_endpoint = "http://localhost:8080/actuator"
+
+    with mock.patch(
+        "chaosspring.api.call_api", return_value=mock_response
+    ) as mock_call_api:
+        enabled = chaosmonkey_enabled(base_url=actuator_endpoint, verify_ssl=False)
+
+    assert enabled
+    mock_call_api.assert_called_once_with(
+        base_url=actuator_endpoint,
+        api_endpoint="chaosmonkey/status",
+        headers=None,
+        timeout=None,
+        verify=False,
         configuration=None,
         secrets=None,
     )
@@ -48,6 +70,7 @@ def test_chaosmonkey_is_enabled_with_headers():
         api_endpoint="chaosmonkey/status",
         headers=headers,
         timeout=None,
+        verify=True,
         configuration=None,
         secrets=None,
     )
@@ -68,6 +91,7 @@ def test_chaosmonkey_is_enabled_fails():
         api_endpoint="chaosmonkey/status",
         headers=None,
         timeout=None,
+        verify=True,
         configuration=None,
         secrets=None,
     )
@@ -89,6 +113,28 @@ def test_chaosmonkey_not_enabled():
         api_endpoint="chaosmonkey/status",
         headers=None,
         timeout=None,
+        verify=True,
+        configuration=None,
+        secrets=None,
+    )
+
+
+def test_chaosmonkey_not_enabled_without_ssl_verification():
+    mock_response = MagicMock(Response, status_code=codes.service_unavailable)
+    actuator_endpoint = "http://localhost:8080/actuator"
+
+    with mock.patch(
+        "chaosspring.api.call_api", return_value=mock_response
+    ) as mock_call_api:
+        enabled = chaosmonkey_enabled(base_url=actuator_endpoint, verify_ssl=False)
+
+    assert not enabled
+    mock_call_api.assert_called_once_with(
+        base_url=actuator_endpoint,
+        api_endpoint="chaosmonkey/status",
+        headers=None,
+        timeout=None,
+        verify=False,
         configuration=None,
         secrets=None,
     )
@@ -118,6 +164,42 @@ def test_watcher_configuration():
         api_endpoint="chaosmonkey/watcher",
         headers=None,
         timeout=None,
+        verify=True,
+        configuration=None,
+        secrets=None,
+    )
+
+    assert "service" in configuration
+    assert configuration["service"] is True
+
+
+def test_watcher_configuration_without_ssl_verification():
+    text_response = {
+        "controller": True,
+        "restController": False,
+        "service": True,
+        "repository": False,
+        "component": False,
+    }
+
+    mock_response = MagicMock(Response, status_code=codes.ok)
+    mock_response.json.return_value = text_response
+
+    actuator_endpoint = "http://localhost:8080/actuator"
+
+    with mock.patch(
+        "chaosspring.api.call_api", return_value=mock_response
+    ) as mock_call_api:
+        configuration = watcher_configuration(
+            base_url=actuator_endpoint, verify_ssl=False
+        )
+
+    mock_call_api.assert_called_once_with(
+        base_url=actuator_endpoint,
+        api_endpoint="chaosmonkey/watcher",
+        headers=None,
+        timeout=None,
+        verify=False,
         configuration=None,
         secrets=None,
     )
@@ -142,6 +224,7 @@ def test_watcher_configuration_fails():
         api_endpoint="chaosmonkey/watcher",
         headers=None,
         timeout=None,
+        verify=True,
         configuration=None,
         secrets=None,
     )
@@ -173,6 +256,42 @@ def test_assaults_configuration():
         api_endpoint="chaosmonkey/assaults",
         headers=None,
         timeout=None,
+        verify=True,
+        configuration=None,
+        secrets=None,
+    )
+    assert "level" in configuration
+    assert configuration["level"] == 3
+
+
+def test_assaults_configuration_without_ssl_verification():
+    text_response = {
+        "level": 3,
+        "latencyRangeStart": 1000,
+        "latencyRangeEnd": 3000,
+        "latencyActive": True,
+        "exceptionsActive": False,
+        "killApplicationActive": False,
+        "restartApplicationActive": False,
+    }
+
+    mock_response = MagicMock(Response, status_code=codes.ok)
+    mock_response.json.return_value = text_response
+
+    actuator_endpoint = "http://localhost:8080/actuator"
+    with mock.patch(
+        "chaosspring.api.call_api", return_value=mock_response
+    ) as mock_call_api:
+        configuration = assaults_configuration(
+            base_url=actuator_endpoint, verify_ssl=False
+        )
+
+    mock_call_api.assert_called_once_with(
+        base_url=actuator_endpoint,
+        api_endpoint="chaosmonkey/assaults",
+        headers=None,
+        timeout=None,
+        verify=False,
         configuration=None,
         secrets=None,
     )
@@ -196,6 +315,7 @@ def test_assaults_configuration_fails():
         api_endpoint="chaosmonkey/assaults",
         headers=None,
         timeout=None,
+        verify=True,
         configuration=None,
         secrets=None,
     )


### PR DESCRIPTION
As per a conversation in the Slack, someone is looking to disable SSL verification with their experiment
using `chaosspring`.

This PR adds the argument `verify_ssl` to the actions and probes in this extension to allow that choice.
