### PR TITLE
Fixes issue where we were incorrectly passing `verify` as a query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/chaostoolkit-incubator/chaostoolkit-spring/compare/0.3.0...HEAD
 
+### Fixed:
+
+* `verify` parameter now passed as a `requests` parameter and not a query param
+
 ## [0.3.0][] - 2021-10-05
 
 [0.3.0]: https://github.com/chaostoolkit-incubator/chaostoolkit-spring/compare/0.2.0...0.3.0

--- a/chaosspring/api.py
+++ b/chaosspring/api.py
@@ -44,7 +44,7 @@ def call_api(
     headers = headers or {}
     headers.setdefault("Accept", "application/json")
 
-    params = {"verify": verify}
+    params = {}
     if timeout:
         params["timeout"] = timeout
 
@@ -54,5 +54,5 @@ def call_api(
         headers.update({"Content-Type": "application/json"})
 
     return requests.request(
-        method=method, url=url, params=params, data=data, headers=headers
+        method=method, url=url, params=params, data=data, headers=headers, verify=verify
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -53,9 +53,10 @@ def test_call_api_without_verification(mocked_request: MagicMock):
     mocked_request.assert_called_once_with(
         method="GET",
         url="http://localhost:8080/actuator/chaosmonkey/status",
-        params={"timeout": 3000, "verify": False},
+        params={"timeout": 3000},
         data=None,
         headers={"Accept": "application/json"},
+        verify=False,
     )
 
 
@@ -82,9 +83,10 @@ def test_call_api_with_verification(mocked_request: MagicMock):
     mocked_request.assert_called_once_with(
         method="GET",
         url="http://localhost:8080/actuator/chaosmonkey/status",
-        params={"timeout": 3000, "verify": True},
+        params={"timeout": 3000},
         data=None,
         headers={"Accept": "application/json"},
+        verify=True,
     )
 
 


### PR DESCRIPTION
After testing from our user it was clear I'd put the `verify` param in the wrong place!

Signed-off-by: Ciaran Evans <ciaran@reliably.com>
