### PR TITLE
Added function to change watchers configuration.

### DIFF
--- a/chaosspring/actions.py
+++ b/chaosspring/actions.py
@@ -98,3 +98,37 @@ def change_assaults_configuration(
         )
 
     return response.text
+
+
+def change_watchers_configuration(
+    base_url: str,
+    watchers_configuration: Dict[str, Any],
+    headers: Dict[str, Any] = None,
+    timeout: float = None,
+    verify_ssl: bool = True,
+    configuration: Configuration = None,
+    secrets: Secrets = None,
+) -> str:
+    """
+    Change Watchers configuration on a specific service.
+    """
+
+    response = api.call_api(
+        base_url=base_url,
+        # Is chaosmonkey/watcher in Chaos Monkey for Spring Boot 2.0.0.-SNAPSHOT
+        api_endpoint="chaosmonkey/watchers",
+        method="POST",
+        watchers_configuration=watchers_configuration,
+        headers=headers,
+        timeout=timeout,
+        verify=verify_ssl,
+        configuration=configuration,
+        secrets=secrets,
+    )
+
+    if response.status_code != codes.ok:
+        raise FailedActivity(
+            f"Change ChaosMonkey Assaults Configuration failed: {response.text}"
+        )
+
+    return response.text

--- a/chaosspring/api.py
+++ b/chaosspring/api.py
@@ -11,6 +11,7 @@ def call_api(
     api_endpoint: str,
     method: str = "GET",
     assaults_configuration: Dict[str, Any] = None,
+    watchers_configuration: Dict[str, Any] = None,
     headers: Dict[str, Any] = None,
     timeout: float = None,
     verify: bool = True,
@@ -51,6 +52,10 @@ def call_api(
     data = None
     if assaults_configuration:
         data = json.dumps(assaults_configuration)
+        headers.update({"Content-Type": "application/json"})
+
+    if watchers_configuration:
+        data = json.dumps(watchers_configuration)
         headers.update({"Content-Type": "application/json"})
 
     return requests.request(

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -7,6 +7,7 @@ from requests import Response, codes
 
 from chaosspring.actions import (
     change_assaults_configuration,
+    change_watchers_configuration,
     disable_chaosmonkey,
     enable_chaosmonkey,
 )
@@ -261,6 +262,89 @@ def test_change_assaults_configuration_fails():
         api_endpoint="chaosmonkey/assaults",
         method="POST",
         assaults_configuration=assaults_configuration,
+        headers=None,
+        timeout=None,
+        verify=True,
+        configuration=None,
+        secrets=None,
+    )
+    assert "Change ChaosMonkey Assaults Configuration failed" in str(ex)
+
+
+def test_change_watchers_configuration():
+    watchers_configuration = {
+        "controller": False,
+        "restController": False,
+        "service": True,
+        "repository": False,
+        "component": False,
+        "restTemplate": False,
+        "webClient": False,
+        "actuatorHealth": False,
+        "beans": [],
+        "beanClasses": [],
+        "excludeClasses": [],
+    }
+
+    mock_response = MagicMock(
+        Response, status_code=codes.ok, text="Watcher config has changed"
+    )
+
+    actuator_endpoint = "http://localhost:8080/actuator"
+    with mock.patch(
+        "chaosspring.api.call_api", return_value=mock_response
+    ) as mock_call_api:
+        changed = change_watchers_configuration(
+            base_url=actuator_endpoint, watchers_configuration=watchers_configuration
+        )
+
+    mock_call_api.assert_called_once_with(
+        base_url=actuator_endpoint,
+        api_endpoint="chaosmonkey/watchers",
+        method="POST",
+        watchers_configuration=watchers_configuration,
+        headers=None,
+        timeout=None,
+        verify=True,
+        configuration=None,
+        secrets=None,
+    )
+    assert changed == "Watcher config has changed"
+
+
+def test_change_watchers_configuration_fails():
+    watchers_configuration = {
+        "controller": False,
+        "restController": False,
+        "service": True,
+        "repository": False,
+        "component": False,
+        "restTemplate": False,
+        "webClient": False,
+        "actuatorHealth": False,
+        "beans": [],
+        "beanClasses": [],
+        "excludeClasses": [],
+    }
+
+    mock_response = MagicMock(Response, status_code=codes.not_found, text="Not Found")
+
+    actuator_endpoint = "http://localhost:8080/actuator"
+
+    with mock.patch(
+        "chaosspring.api.call_api", return_value=mock_response
+    ) as mock_call_api:
+        with pytest.raises(FailedActivity) as ex:
+            change_watchers_configuration(
+                base_url=actuator_endpoint,
+                watchers_configuration=watchers_configuration,
+            )
+
+    mock_call_api.assert_called_once_with(
+        base_url=actuator_endpoint,
+        api_endpoint="chaosmonkey/watchers",
+        method="POST",
+        watchers_configuration=watchers_configuration,
         headers=None,
         timeout=None,
         verify=True,


### PR DESCRIPTION
Hi,
I just started using your library and needed this functionality. This enables to change the watchers for Chaos Monkey for Spring Boot. I used the "/watchers" endpoint of the current CMSB version 3.1.0. In CMSB  2.0.0-SNAPSHOT the endpoint is "/watcher".

This resolves issue #3.

Best Regards